### PR TITLE
Fixed Gitter image badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Doing_bayesian_data_analysis  
 ============================  
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/aloctavodia/Doing_bayesian_data_analysis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
-
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/aloctavodia/Doing_bayesian_data_analysis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This repository contains the Python version of the R programs described in the great book [Doing bayesian data analysis (first edition)](http://doingbayesiandataanalysis.blogspot.com.ar) by John K. Kruschke (AKA *the puppy book*).
 


### PR DESCRIPTION
The Gitter badge did't render because of a type in the image url. 
The type is now fixed.