### PR TITLE
docs: Fix a few typos

### DIFF
--- a/06_BernGrid.py
+++ b/06_BernGrid.py
@@ -1,5 +1,5 @@
 """
-Inferring a binomial proportion via grid aproximation.
+Inferring a binomial proportion via grid approximation.
 """
 import matplotlib.pyplot as plt
 plt.style.use('seaborn-darkgrid')

--- a/08_BernTwoGrid.py
+++ b/08_BernTwoGrid.py
@@ -1,5 +1,5 @@
 """
-Inferring two binomial proportions via grid aproximation.
+Inferring two binomial proportions via grid approximation.
 """
 from __future__ import division
 import matplotlib.pyplot as plt

--- a/15_YmetricXsinglePyMC.py
+++ b/15_YmetricXsinglePyMC.py
@@ -20,7 +20,7 @@ y = norm.rvs(true_mu, true_std, 500)
 with pm.Model() as model:
     # define the priors
     sd = pm.HalfNormal('sd', 25)
-    mu = pm.Normal('mu', mu=0, sd=100) # PyMC support precission and std
+    mu = pm.Normal('mu', mu=0, sd=100) # PyMC support precision and std
     #define the likelihood
     yl = pm.Normal('yl', mu, sd, observed=y)
 #   Generate a MCMC chain

--- a/16_SimpleRobustLinearRegressionPyMC.py
+++ b/16_SimpleRobustLinearRegressionPyMC.py
@@ -29,7 +29,7 @@ y_sd = np.std(y)
 zx = (x - x_m) / x_sd
 zy = (y - y_m) / y_sd
 
-tdf_gain = 1 # 1 for low-baised tdf, 100 for high-biased tdf
+tdf_gain = 1 # 1 for low-biased tdf, 100 for high-biased tdf
 
 # THE MODEL
 with pm.Model() as model:


### PR DESCRIPTION
There are small typos in:
- 06_BernGrid.py
- 08_BernTwoGrid.py
- 15_YmetricXsinglePyMC.py
- 16_SimpleRobustLinearRegressionPyMC.py

Fixes:
- Should read `approximation` rather than `aproximation`.
- Should read `precision` rather than `precission`.
- Should read `biased` rather than `baised`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md